### PR TITLE
feat(build): add NuGet Central Package Management and upgrade dependencies

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>1.2.3</VersionPrefix>
+        <VersionPrefix>1.2.4</VersionPrefix>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
 
         <!-- Other useful metadata -->
@@ -22,7 +22,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+        <PackageReference Include="Microsoft.SourceLink.GitHub">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,48 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup Label="AWS SDK">
+    <PackageVersion Include="AWSSDK.DynamoDBv2" Version="4.0.14" />
+    <PackageVersion Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.3.22" />
+  </ItemGroup>
+  <ItemGroup Label="Microsoft">
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.103" />
+  </ItemGroup>
+  <!--
+    NOTE: This repo intentionally pins Microsoft.Extensions packages by TFM.
+    This mirrors the conditional versions previously specified in the individual .csproj files.
+  -->
+  <ItemGroup Label="Microsoft (TFM pinned)" Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'netstandard2.1'">
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
+  </ItemGroup>
+  <ItemGroup Label="Microsoft (TFM pinned)" Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.13" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.13" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.13" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.13" />
+  </ItemGroup>
+  <ItemGroup Label="Microsoft (TFM pinned)" Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.3" />
+  </ItemGroup>
+  <ItemGroup Label="OpenTelemetry">
+    <PackageVersion Include="OpenTelemetry" Version="1.15.0" />
+  </ItemGroup>
+  <ItemGroup Label="Testing">
+    <PackageVersion Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
+    <PackageVersion Include="AutoFixture.Xunit3" Version="4.19.0" />
+    <PackageVersion Include="AwesomeAssertions" Version="9.3.0" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.3.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.4.1" />
+    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
+  </ItemGroup>
+</Project>

--- a/DynamoDb.DistributedLock.slnx
+++ b/DynamoDb.DistributedLock.slnx
@@ -8,6 +8,7 @@
   <Folder Name="/Solution Items/">
     <File Path="CLAUDE.md" />
     <File Path="Directory.Build.props" />
+    <File Path="Directory.Packages.props" />
     <File Path="icon.png" />
     <File Path="LICENSE" />
     <File Path="README.md" />

--- a/src/DynamoDb.DistributedLock.Observability/DynamoDb.DistributedLock.Observability.csproj
+++ b/src/DynamoDb.DistributedLock.Observability/DynamoDb.DistributedLock.Observability.csproj
@@ -19,7 +19,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="OpenTelemetry" Version="1.13.1" />
+        <PackageReference Include="OpenTelemetry" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/DynamoDb.DistributedLock/DynamoDb.DistributedLock.csproj
+++ b/src/DynamoDb.DistributedLock/DynamoDb.DistributedLock.csproj
@@ -19,23 +19,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AWSSDK.DynamoDBv2" Version="4.0.9.5" />
-        <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.3.11" />
-    </ItemGroup>
-    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1'">
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
-    </ItemGroup>
-    <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.11" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.11" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.11" />
-    </ItemGroup>
-    <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.0" />
+        <PackageReference Include="AWSSDK.DynamoDBv2" />
+        <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+        <PackageReference Include="Microsoft.Extensions.Options" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/DynamoDb.DistributedLock.Tests/DynamoDb.DistributedLock.Tests.csproj
+++ b/test/DynamoDb.DistributedLock.Tests/DynamoDb.DistributedLock.Tests.csproj
@@ -24,27 +24,19 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.1"/>
-        <PackageReference Include="AutoFixture.Xunit3" Version="4.19.0"/>
-        <PackageReference Include="AwesomeAssertions" Version="9.3.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-        <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.0.6" />
-        <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="9.10.0" />
-        <PackageReference Include="NSubstitute" Version="5.3.0"/>
-        <PackageReference Include="xunit.v3" Version="3.2.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+        <PackageReference Include="AutoFixture.AutoNSubstitute"/>
+        <PackageReference Include="AutoFixture.Xunit3"/>
+        <PackageReference Include="AwesomeAssertions" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" />
+        <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+        <PackageReference Include="NSubstitute"/>
+        <PackageReference Include="xunit.v3.mtp-v2" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-    </ItemGroup>
-    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1'">
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    </ItemGroup>
-    <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.11" />
-    </ItemGroup>
-    <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Summary

> - Introduce `Directory.Packages.props` to centralize all NuGet package version management across the solution
> - Remove `Version` attributes from all `PackageReference` entries in `.csproj` files and `Directory.Build.props`
> - Consolidate TFM-conditional `ItemGroup`s in project files — versions are now managed centrally via TFM-pinned groups in `Directory.Packages.props`
> - Upgrade all packages to latest versions (AWS SDK, Microsoft.Extensions, OpenTelemetry, testing packages, SourceLink)
> - Add `Directory.Packages.props` to Solution Items in the `.slnx` file
> - Bump `VersionPrefix` to 1.2.4

---

## ✅ Checklist

- [x] My changes build cleanly
- [x] I've added/updated relevant tests
- [ ] I've added/updated documentation or README
- [x] I've followed the coding style for this project
- [x] I've tested the changes locally (if applicable)

---

## 🧪 Related Issues or PRs

N/A

---

## 💬 Notes for Reviewers

> The `Directory.Packages.props` is organized with labeled `ItemGroup`s (AWS SDK, Microsoft, Microsoft TFM pinned, OpenTelemetry, Testing) following the same pattern used in other LayeredCraft repos. TFM-conditional package versions for `Microsoft.Extensions.*` are pinned per target framework (net8.0, net9.0, net10.0) in the central file, which allowed removing the conditional `ItemGroup`s from individual `.csproj` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)